### PR TITLE
Feature/log handling

### DIFF
--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -206,6 +206,8 @@ sub external_process_handler {
       system("$script 1> $out 2> $err");
     }
     catch { die $_; };
+
+    unlink $script; # only leave scripts if we fail
   }
 
   return 1;

--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -221,7 +221,7 @@ sub _create_script {
     print $SH qq{/usr/bin/time $c\n};
   }
   close $SH;
-  chmod '0755', $script;
+  chmod "0777", $script;
   return $script;
 }
 

--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -33,7 +33,7 @@ use File::Path qw(make_path);
 use Try::Tiny qw(try catch finally);
 use Capture::Tiny qw(capture);
 use IO::File;
-use Const:Fast qw(const);
+use Const::Fast qw(const);
 
 BEGIN {
   if($Config{useithreads}) { use threads; }

--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -153,6 +153,7 @@ sub _suitable_threads {
 sub success_exists {
   my ($tmp, @indexes) = @_;
   my ($type) = (caller(1))[3];
+  $type =~ s/::/_/g;
   my $file = join '.', $type, @indexes;
   my $path = File::Spec->catfile($tmp, $file);
   if(-e $path) {
@@ -165,6 +166,7 @@ sub success_exists {
 sub touch_success {
   my ($tmp, @indexes) = @_;
   my ($type) = (caller(1))[3];
+  $type =~ s/::/_/g;
   make_path($tmp) unless(-d $tmp);
   my $file = join '.', $type, @indexes;
   my $path = File::Spec->catfile($tmp, $file);

--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -39,7 +39,7 @@ BEGIN {
   if($Config{useithreads}) { use threads; }
 };
 
-const my $SCRIPT_OCT_MODE = 0777;
+const my $SCRIPT_OCT_MODE => 0777;
 
 our $OUT_ERR = 1;
 

--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -208,7 +208,7 @@ sub external_process_handler {
     my $err = File::Spec->catfile($tmp, "$caller.$suffix.err");
 
     try {
-      system("$script 1> $out 2> $err");
+      system("/usr/bin/time $script 1> $out 2> $err");
     }
     catch { die $_; };
 
@@ -224,9 +224,8 @@ sub _create_script {
   my $script = "$stub.sh";
   open my $SH, '>', $script or die "Cannot create $script: $!\n";
   print $SH qq{#!/bin/bash\nset -eux\n};
-  for my $c(@{$commands}) {
-    print $SH qq{/usr/bin/time $c\n};
-  }
+  print $SH join qq{\n}, @{$commands};
+  print $SH qq{\n};
   close $SH;
   chmod $SCRIPT_OCT_MODE, $script;
   return $script;

--- a/lib/PCAP/Threaded.pm
+++ b/lib/PCAP/Threaded.pm
@@ -33,10 +33,13 @@ use File::Path qw(make_path);
 use Try::Tiny qw(try catch finally);
 use Capture::Tiny qw(capture);
 use IO::File;
+use Const:Fast qw(const);
 
 BEGIN {
   if($Config{useithreads}) { use threads; }
 };
+
+const my $SCRIPT_OCT_MODE = 0777;
 
 our $OUT_ERR = 1;
 
@@ -223,7 +226,7 @@ sub _create_script {
     print $SH qq{/usr/bin/time $c\n};
   }
   close $SH;
-  chmod "0777", $script;
+  chmod $SCRIPT_OCT_MODE, $script;
   return $script;
 }
 

--- a/t/pcapThreaded.t
+++ b/t/pcapThreaded.t
@@ -77,7 +77,7 @@ subtest 'completion utility checks' => sub {
   is(PCAP::Threaded::success_exists($dir, 1), 0, 'No success file');
   ok(PCAP::Threaded::touch_success($dir, 1), 'No success file');
   is(PCAP::Threaded::success_exists($dir, 1), 1, 'Success file present');
-  ok(PCAP::Threaded::external_process_handler($dir, 'ls', [1]), 'External process executes');
+  ok(PCAP::Threaded::external_process_handler($dir, 'ls', 1), 'External process executes');
 };
 
 subtest 'thread divisor checks' => sub {


### PR DESCRIPTION
Makes file paths more portable and fixes up the problem where output for a job occasionally ended up in the wrong file.  This is achieved by generating a shell script with the commands and redirecting the output in the shell rather than by using Capture Tiny.

System failures are handled by `autodie` checks.

@drjsanger , could you review.  I've done a standard run of `cgpbox` and verified the results.